### PR TITLE
Improve guidelines for multiplayer compatibility

### DIFF
--- a/mcguide/9-规范开发/5-多人联机适配规范.md
+++ b/mcguide/9-规范开发/5-多人联机适配规范.md
@@ -11,11 +11,11 @@ selection: true
 
 最近，在山头测试中，我们发现很多开发者的模组明明在单人游戏运行是非常正常的，但在山头、多人联机环境下就会出现功能无效或者异常的情况
 
-后面我们发现，实际上只要遵循 ServerSystem 和 ClientSystem 分离的原则。基本上就能保证开发的模组兼容山头服和多人联机
+只要遵循 ServerSystem 与 ClientSystem 严格分离 的原则，大部分兼容性问题都能自然消失。
 
 ## 开发范例
 
-> 下方代码仅供参考和通俗化解释，并不能实际运行！
+> 下方代码为错误示范。仅供参考和通俗化解释，并不能实际运行！
 
 **modClient.py**
 ```python
@@ -36,12 +36,12 @@ class ModClient(clientApi.GetClientSystemCls()):
 **modServer.py**
 ```python
 import mod.client.extraClientApi as serverApi
-from xxx.xxx.xxx import ModClient
+from xxx.xxx.xxx import ModClient #错误引用客户端侧
 
 class ModServer(serverApi.GetServerSystemCls()):
 
     def ServerRegister(self):
-        ModClient.NoClientApiRegister()
+        ModClient.NoClientApiRegister() #在多人游戏出现功能无效或者异常
         print("register successfully")
         # TODO
 ```


### PR DESCRIPTION
This pull request updates the documentation in `mcguide/9-规范开发/5-多人联机适配规范.md` to clarify best practices for multiplayer compatibility and to provide clearer code examples. The main focus is on emphasizing the strict separation between `ServerSystem` and `ClientSystem` and highlighting common mistakes through annotated code samples.

Documentation improvements and clarification:

* Reworded the explanation to stress the importance of strict separation between `ServerSystem` and `ClientSystem` for resolving most compatibility issues in multiplayer environments.
* Updated code sample annotations to explicitly label the provided code as an error demonstration and clarified that it is for reference only.
* Added comments in the server-side code sample to indicate the incorrect client-side import and to explain that this leads to non-functional or abnormal behavior in multiplayer games.Clarified the principle of separating ServerSystem and ClientSystem for better compatibility in multiplayer environments. Updated example code to highlight incorrect client-side imports.